### PR TITLE
Update train.sh

### DIFF
--- a/train.sh
+++ b/train.sh
@@ -10,7 +10,7 @@
 # arg 3 CANDLE_CONFIG
 
 ### Path to your CANDLEized model's main Python script###
-CANDLE_MODEL=/usr/local/NIHGCN/nihgcn_baseline_pytorch.py
+CANDLE_MODEL=nihgcn_baseline_pytorch.py
 
 ### Set env if CANDLE_MODEL is not in same directory as this script
 IMPROVE_MODEL_DIR=${IMPROVE_MODEL_DIR:-$( dirname -- "$0" )}


### PR DESCRIPTION
Don't specify full path to model script. Changed it to name of model script. Per convention the train.sh script is in the same directory as the model script in the repo.